### PR TITLE
Jasmine unit test fixes

### DIFF
--- a/src/Web/ClientApp/src/app/app.component.spec.ts
+++ b/src/Web/ClientApp/src/app/app.component.spec.ts
@@ -1,10 +1,11 @@
-import { TestBed } from '@angular/core/testing';
+import { TestBed  } from '@angular/core/testing';
+import { RouterModule } from '@angular/router';
 import { AppComponent } from './app.component';
 
 describe('AppComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [AppComponent],
+      imports: [AppComponent, RouterModule.forRoot([])],
     }).compileComponents();
   });
 

--- a/src/Web/ClientApp/src/app/components/table.list-item/table-list-item.component.spec.ts
+++ b/src/Web/ClientApp/src/app/components/table.list-item/table-list-item.component.spec.ts
@@ -1,20 +1,42 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing'; 
+import { NgbHighlight, NgbModal  } from '@ng-bootstrap/ng-bootstrap';
+import { FormsModule } from '@angular/forms'; 
+import { MmDdYYYYDatePipe } from '../../pipes/mm--dd-yyyy-date.pipe';
 
 import { TableListItem } from "./table-list-item.component";
+import { Patient } from '../../dataModels/patient';
 
 describe('TableListItem', () => {
   let component: TableListItem;
   let fixture: ComponentFixture<TableListItem>;
 
+  // Stubs:
+  let patientStubInput:Patient = {
+    id: 1,
+    firstName: 'John',
+    lastName: 'Doe',
+    birthDate: new Date('2021-01-01'),
+    genderDescription: 'Male',
+    dateCreated: new Date('2021-01-01'),
+    dateUpdated: new Date('2021-01-01'),
+  };
+
+  let datePipeStub: Partial<MmDdYYYYDatePipe> = {
+    transform: () => new Date('2021-01-01'),};
+
+
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [TableListItem]
+      imports: [TableListItem, NgbHighlight, FormsModule],
+      providers: [{provide : MmDdYYYYDatePipe, useValue: datePipeStub}],
     })
     .compileComponents();
     
     fixture = TestBed.createComponent(TableListItem);
     component = fixture.componentInstance;
+    component.patient = patientStubInput;
     fixture.detectChanges();
+    component.ngOnInit();
   });
 
   it('should create', () => {


### PR DESCRIPTION
3 of the default jasmine unit tests were failing due to imports and @Input after ng generate scaffolded the original boilerplate tests.  Tests updated to pass.